### PR TITLE
Have ProcessParameters callbacks return Futures so they can be awaited

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -39,7 +39,7 @@ async fn main() {
             on_update_game_session: Box::new(|update_game_session| {
                 Box::pin(async move { log::debug!("{:?}", update_game_session) })
             }),
-            on_process_terminate: Box::new(|| Box::pin(async { () })),
+            on_process_terminate: Box::new(|| Box::pin(async {})),
             on_health_check: Box::new(|| Box::pin(async { true })),
             port: 14000,
             log_parameters: LogParameters { log_paths: vec!["test".to_string()] },

--- a/src/process_parameters.rs
+++ b/src/process_parameters.rs
@@ -1,9 +1,24 @@
-pub type OnStartGameSessionType =
-    dyn Fn(crate::entity::GameSession) + std::marker::Send + std::marker::Sync;
-pub type OnUpdateGameSessionType =
-    dyn Fn(crate::entity::UpdateGameSession) + std::marker::Send + std::marker::Sync;
-pub type OnProcessTerminateType = dyn Fn() + std::marker::Send + std::marker::Sync;
-pub type OnHealthCheckType = dyn Fn() -> bool + std::marker::Send + std::marker::Sync;
+pub type OnStartGameSessionOutputType =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + std::marker::Send>>;
+pub type OnStartGameSessionType = dyn Fn(crate::entity::GameSession) -> OnStartGameSessionOutputType
+    + std::marker::Send
+    + std::marker::Sync;
+
+pub type OnUpdateGameSessionOutputType =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + std::marker::Send>>;
+pub type OnUpdateGameSessionType = dyn Fn(crate::entity::UpdateGameSession) -> OnUpdateGameSessionOutputType
+    + std::marker::Send
+    + std::marker::Sync;
+
+pub type OnProcessTerminateOutputType =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + std::marker::Send>>;
+pub type OnProcessTerminateType =
+    dyn Fn() -> OnProcessTerminateOutputType + std::marker::Send + std::marker::Sync;
+
+pub type HealthCheckOutputType =
+    std::pin::Pin<Box<dyn std::future::Future<Output = bool> + std::marker::Send>>;
+pub type OnHealthCheckType =
+    dyn Fn() -> HealthCheckOutputType + std::marker::Send + std::marker::Sync;
 
 /// This data type contains the set of parameters sent to the GameLift service
 /// in a [ProcessReady](crate::api::Api::process_ready) call.

--- a/src/web_socket_listener.rs
+++ b/src/web_socket_listener.rs
@@ -56,18 +56,23 @@ impl WebSocketListener {
                             callback_handler
                                 .lock()
                                 .await
-                                .on_start_game_session(message.game_session);
+                                .on_start_game_session(message.game_session)
+                                .await;
                         }
                         ReceivedMessageType::UpdateGameSession(message) => {
                             log::info!("Received UpdateGameSession event");
 
                             let game_session = message.game_session.unwrap();
                             let update_reason = message.update_reason;
-                            callback_handler.lock().await.on_update_game_session(
-                                game_session,
-                                update_reason,
-                                message.backfill_ticket_id,
-                            );
+                            callback_handler
+                                .lock()
+                                .await
+                                .on_update_game_session(
+                                    game_session,
+                                    update_reason,
+                                    message.backfill_ticket_id,
+                                )
+                                .await;
                         }
                         ReceivedMessageType::TerminateProcess(message) => {
                             log::info!("Received TerminateProcess event");
@@ -75,7 +80,8 @@ impl WebSocketListener {
                             callback_handler
                                 .lock()
                                 .await
-                                .on_terminate_process(message.termination_time.unwrap());
+                                .on_terminate_process(message.termination_time.unwrap())
+                                .await;
                         }
                     }
                 } else if msg.is_close() {


### PR DESCRIPTION
This is the other change I mentioned in https://github.com/zamazan4ik/aws-gamelift-server-sdk-rs/pull/2. It makes the ProcessParameters callbacks return futures so they can be awaited at the caller rather than having to spawn tasks internally. It's debatable I think if it's actually cleaner since it requires the pinned Box but I think if async callbacks ever get stabilized that would clean up nicely.

The other big thing obviously is that this is a breaking change. I don't know how much impact that would actually have on anyone and I think it's pretty easy to adjust for. Either way, here it is if it seems worth taking.