### PR TITLE
feat: maintenance update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-gamelift-server-sdk-rs"
-version = "0.1.0"
-edition = "2018"
+version = "0.2.0"
+edition = "2021"
 description = "AWS GameLift Server SDK for Rust"
 repository = "https://github.com/ZaMaZaN4iK/aws-gamelift-server-sdk-rs"
 documentation = "https://docs.rs/aws-gamelift-server-sdk-rs"
@@ -16,25 +16,25 @@ default = ["with-serde"]
 with-serde = ["protobuf/with-serde"]
 
 [dependencies]
-bytes = "1.0.1"
-futures-util = { version = "0.3.15", features = ["sink"] }
+bytes = "1.1.0"
+futures-util = { version = "0.3.19", features = ["sink"] }
 log = "0.4.14"
-protobuf = { version = "2.23.0", features = ["with-serde"] }
-reqwest = { version = "0.11.3", default-features = false }
-serde = "1.0.126"
-serde_json = "1.0.64"
-strum = "0.20.0"
-strum_macros = "0.20.1"
-thiserror = "1.0.24"
-tokio = { version = "1.5.0", features = ["macros", "net", "rt-multi-thread", "time"] }
-tokio-tungstenite = "0.14.0"
+protobuf = { version = "2.25.2", features = ["with-serde"] }
+reqwest = { version = "0.11.8", default-features = false }
+serde = "1.0.133"
+serde_json = "1.0.74"
+strum = "0.23.0"
+strum_macros = "0.23.1"
+thiserror = "1.0.30"
+tokio = { version = "1.15.0", features = ["macros", "net", "rt-multi-thread", "time"] }
+tokio-tungstenite = "0.16.1"
 
 [build-dependencies]
-protobuf-codegen-pure = "2.23.0"
+protobuf-codegen-pure = "2.25.2"
 
 [dev-dependencies]
-env_logger = "0.8.3"
-once_cell = "1.8.0-pre.1"
+env_logger = "0.9.0"
+once_cell = "1.9.0"
 
 [profile.release]
 opt-level = 3

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -78,7 +78,7 @@ pub struct Player {
     pub latency_in_ms: Option<std::collections::HashMap<String, i32>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum_macros::ToString)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum_macros::Display)]
 pub enum PlayerSessionCreationPolicy {
     NotSet,
     AcceptAll,


### PR DESCRIPTION
- bump to the new version - 0.2.0 since we have breaing changes in the API
- bump Rust edition to 2021
- update dependencies
- fix using deprecated stuff

Tested:
- Local build